### PR TITLE
fix(pdf-viewer): render PDF pages on Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # build output
 dist/
+.vercel/
+
+# PDF.js worker copied into public/ by the Vite plugin at build time
+public/pdf.worker.min.mjs
 
 # generated types
 .astro/

--- a/src/components/activities/PdfSlickViewer.tsx
+++ b/src/components/activities/PdfSlickViewer.tsx
@@ -37,7 +37,10 @@ export default function PdfSlickViewer({ src }: PdfSlickViewerProps) {
               <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
             </svg>
           </button>
-          <span className="min-w-[5.5rem] text-center text-sm font-medium text-slate-300">
+          <span
+            className="text-center text-sm font-medium text-slate-300"
+            style={{ minWidth: "5.5rem" }}
+          >
             {numPages ? `${pageNumber} / ${numPages}` : "—"}
           </span>
           <button
@@ -65,7 +68,10 @@ export default function PdfSlickViewer({ src }: PdfSlickViewerProps) {
               <path strokeLinecap="round" strokeLinejoin="round" d="M5 12h14" />
             </svg>
           </button>
-          <span className="min-w-[3.5rem] text-center text-sm font-medium text-slate-300">
+          <span
+            className="text-center text-sm font-medium text-slate-300"
+            style={{ minWidth: "3.5rem" }}
+          >
             {Math.round(scale * 100)}%
           </span>
           <button
@@ -94,7 +100,7 @@ export default function PdfSlickViewer({ src }: PdfSlickViewerProps) {
       </div>
 
       {/* Visor */}
-      <div className="relative h-[600px] w-full bg-slate-200">
+      <div className="relative w-full bg-slate-200" style={{ height: "600px" }}>
         {error ? (
           <div className="absolute inset-0 grid place-items-center px-6 text-center text-sm text-slate-600">
             No se pudo cargar el documento PDF.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,10 @@
 @import "tailwindcss";
 
+/* La detección automática de Tailwind 4 no siempre escanea las islas React (.tsx)
+   durante el build de producción, por lo que las clases con valores arbitrarios
+   usadas solo ahí no se generaban. Registramos explícitamente las fuentes del src. */
+@source "../**/*.{astro,html,js,jsx,ts,tsx}";
+
 /* ===========================================================
    Paleta "Aurora Violeta" — tokens de tema
    Basada en el violeta del logo System Soft (#7216f4)


### PR DESCRIPTION
## Problem

On the Vercel deployment the PDF viewer showed its toolbar but the document never appeared — even though the file loaded correctly.

## Root cause

Diagnosed live with the Chrome DevTools Protocol against the production deployment:

- The document **loaded fine** (`pages: 5`, no network failures, no exceptions).
- But **no page canvas was painted** (`canvas: 0`).
- The scroll container (`relative h-[600px]`) had a **computed height of 0**, while the inner viewer measured 4157px.

The `h-[600px]` class was missing from the production CSS bundle. Tailwind 4's automatic content detection did not scan the React island (`.tsx`) during the production build, so arbitrary-value classes used **only** in that file were never generated. (Common classes like `w-full` survived because they're used across the `.astro` files.) With a 0-height `overflow:auto` container, no page intersected the viewport, so PDF.js's lazy renderer never drew any canvas. It worked in `dev` because Tailwind detects classes from the Vite module graph on demand.

## Fix

- **Inline styles** for the viewer container height and the toolbar min-widths, so the critical dimensions never depend on Tailwind purging.
- **`@source`** directive in `global.css` so Tailwind explicitly scans all `src` files (including `.tsx` islands) for future arbitrary-value classes.
- **.gitignore** the build-generated `public/pdf.worker.min.mjs` and `.vercel/` output.

## Verification

- Confirmed the bug reproduces in the local production build (the arbitrary values were absent from `dist/client/_astro/*.css`).
- After the fix, `height:"600px"` is emitted directly in the client JS bundle, applied inline to the element — immune to CSS purging.

## Test plan

- [ ] Deploy preview and open any activity page; the PDF renders (not just the toolbar).
- [ ] Page navigation, zoom, and download still work.
- [ ] Toolbar page/zoom counters keep their width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)